### PR TITLE
Let renovate do the automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
     "enabled": true,
     "automerge": true,
     "automergeType": "pr",
-    "platformAutomerge": true
+    "platformAutomerge": false
   },
   "packageRules": [
     {


### PR DESCRIPTION
Renovate's docs mention that sometimes the native `platformAutomerge` setting does not work, so let's disable that and see if it works when renovate does the merge.