### PR TITLE
transfomer: ignore azure images with invalid timestamp

### DIFF
--- a/src/cloudimagedirectory/transform/transform.py
+++ b/src/cloudimagedirectory/transform/transform.py
@@ -166,12 +166,16 @@ class TransformerAZURE(Transformer):
 
                 content["hyperVGeneration"] = "unknown"
 
-                image_data = azure.format_image(content)
-                image_name = image_data["name"].replace(" ", "_").lower()
-                data_entry = connection.DataEntry(
-                    f"azure/{region}/{image_name}", image_data
-                )
+                try:
+                    image_data = azure.format_image(content)
+                    image_name = image_data["name"].replace(" ", "_").lower()
+                    data_entry = connection.DataEntry(
+                        f"azure/{region}/{image_name}", image_data
+                    )
 
-                results.append(data_entry)
+                    results.append(data_entry)
+                except:
+                    print("Could not format image, sku: " + content["sku"] + " offer: " + content["offer"])
+
 
         return results


### PR DESCRIPTION
Belongs to https://github.com/redhatcloudx/cloud-image-directory/issues/403

See: https://github.com/redhatcloudx/cloud-image-directory/actions/runs/4530591649/jobs/7979718756#step:11:32