### PR TITLE
Fix Azure image transformation fail on broken timestamp

### DIFF
--- a/src/cloudimagedirectory/transform/transform.py
+++ b/src/cloudimagedirectory/transform/transform.py
@@ -161,11 +161,7 @@ class TransformerAZURE(Transformer):
             region = os.path.basename(raw.filename).split(".")[0]
 
             for content in raw.content:
-                # TODO: Solve bug: the data parsing for this one version didn't work
-                if (
-                    content["publisher"] != "RedHat"
-                    or content["version"] == "8.2.2020270811"
-                ):
+                if content["publisher"] != "RedHat":
                     continue
 
                 content["hyperVGeneration"] = "unknown"

--- a/src/cloudimagedirectory/update_images/azure.py
+++ b/src/cloudimagedirectory/update_images/azure.py
@@ -367,6 +367,19 @@ def parse_image_version(image_version: str) -> dict[str, str]:
     return {}
 
 
+def convert_date(date: str) -> str:
+    """Convert timestamp to date string This fallback is necessary as Azure
+    timestamps are inconsistent and can either follow yyyymmdd or yyyyddmm.
+
+    Returns:
+        Date as string following the structure "%Y-%m-%d"
+    """
+    try:
+        return datetime.strptime(date, "%Y%m%d").strftime("%Y-%m-%d")
+    except:
+        return datetime.strptime(date, "%Y%d%m").strftime("%Y-%m-%d")
+
+
 def format_all_images() -> object:
     """Retrieve all Azure images and return a simplified data representation.
 
@@ -402,9 +415,7 @@ def format_image(image: dict[str, str]) -> dict[str, str]:
     sku = image["sku"]
     offer = image["offer"]
 
-    date = datetime.strptime(additional_information["date"], "%Y%m%d").strftime(
-        "%Y-%m-%d"
-    )
+    date = convert_date(additional_information["date"])
     version = additional_information["version"]
 
     name = f"{offer} {sku} {arch}"

--- a/tests/update_images/test_azure.py
+++ b/tests/update_images/test_azure.py
@@ -426,3 +426,23 @@ def test_failing_to_parse_image_version():
     parsed = azure.parse_image_version(invalid_version)
 
     assert parsed == {}
+
+
+def test_convert_date():
+    """Test successfully convert timestamp to date string."""
+    yyyymmdd_date = azure.convert_date("20230124")
+
+    assert yyyymmdd_date == "2023-01-24"
+
+    yyyyddmm_date = azure.convert_date("20232401")
+
+    assert yyyyddmm_date == "2023-01-24"
+
+
+def test_fail_to_convert_date():
+    """Test fail to convert broken timestamp."""
+    with pytest.raises(Exception, match=r"unconverted data remains: 01"):
+        azure.convert_date("20239901")
+
+    with pytest.raises(Exception, match=r"unconverted data remains: 9"):
+        azure.convert_date("20230199")


### PR DESCRIPTION
Because we just can't have nice things.

Timestamps on Azure can either be YYYYMMDD or YYYYDDMM.

Closes #403 