### PR TITLE
transformer: add index page file

### DIFF
--- a/src/cloudimagedirectory/transform/transform.py
+++ b/src/cloudimagedirectory/transform/transform.py
@@ -103,17 +103,29 @@ class TransformerIdxListImageLatest(Transformer):
                 chunked_list.append(chunk)
                 chunk = []
 
+        provider = ""
+        if self.provider != "":
+            provider = "-" + self.provider
+
+        first = 0
         results = []
-        for page in range(0, len(chunked_list)):
-            provider = ""
-            if self.provider != "":
-                provider = "-" + self.provider
+        for page in range(first, len(chunked_list)):
             data_entry = connection.DataEntry(
                 f"idx/list/sort-by-date{provider}/{page}", chunked_list[page]
             )
             results.append(data_entry)
 
+        page_entry = connection.DataEntry(
+            f"idx/list/sort-by-date{provider}/pages", {
+                "first": first,
+                "last": len(chunked_list)-1,
+                "entries": self.chunk_size,
+            }
+        )
+        results.append(page_entry)
+
         return results
+
 
 
 class TransformerIdxListImageLatestGoogle(TransformerIdxListImageLatest):

--- a/src/cloudimagedirectory/transform/transform.py
+++ b/src/cloudimagedirectory/transform/transform.py
@@ -116,16 +116,16 @@ class TransformerIdxListImageLatest(Transformer):
             results.append(data_entry)
 
         page_entry = connection.DataEntry(
-            f"idx/list/sort-by-date{provider}/pages", {
+            f"idx/list/sort-by-date{provider}/pages",
+            {
                 "first": first,
-                "last": len(chunked_list)-1,
+                "last": len(chunked_list) - 1,
                 "entries": self.chunk_size,
-            }
+            },
         )
         results.append(page_entry)
 
         return results
-
 
 
 class TransformerIdxListImageLatestGoogle(TransformerIdxListImageLatest):

--- a/tests/transformer/test_transform.py
+++ b/tests/transformer/test_transform.py
@@ -104,4 +104,4 @@ def test_transformeridxlistimagelatest():
     assert expected_page2.content == results[1].content
 
     # verify that only two pages exist
-    assert 2 == len(results)
+    assert 3 == len(results)


### PR DESCRIPTION
With the new file we should have this path: `v1/idx/list/sort-by-date/pages`  with this content:
```
{
  "first": 0,
  "last": 360,
  "entries": 50,
}
```

This file should help us to know for the frontend how many pages we want to serve.