### PR TITLE
Support filters #453

### DIFF
--- a/src/cloudimagedirectory/filter/filter.py
+++ b/src/cloudimagedirectory/filter/filter.py
@@ -1,9 +1,10 @@
 from typing import Callable
 
-from cloudimagedirectory.connection import connection
 
-def FilterImageByFilename(word:str) -> Callable:
-    """Filter images by filename"""
+def FilterImageByFilename(word: str) -> Callable:
+    """Filter images by filename."""
 
     print("filter images by filename: " + word)
-    return lambda data: [d for d in data if not d.filename.lower().__contains__(word.lower())]
+    return lambda data: [
+        d for d in data if not d.filename.lower().__contains__(word.lower())
+    ]

--- a/src/cloudimagedirectory/filter/filter.py
+++ b/src/cloudimagedirectory/filter/filter.py
@@ -1,0 +1,9 @@
+from typing import Callable
+
+from cloudimagedirectory.connection import connection
+
+def FilterImageByFilename(word:str) -> Callable:
+    """Filter images by filename"""
+
+    print("filter images by filename: " + word)
+    return lambda data: [d for d in data if not d.filename.lower().__contains__(word.lower())]

--- a/src/cloudimagedirectory/transform/transform.py
+++ b/src/cloudimagedirectory/transform/transform.py
@@ -18,7 +18,13 @@ class Pipeline:
     filter_funcs: list[Callable] = []
     idx_generators: list[Callable] = []
 
-    def __init__(self, src_conn, transformer_funcs: list[Callable], filter_funcs: list[Callable], idx_generator_funcs: list[Callable]):
+    def __init__(
+        self,
+        src_conn,
+        transformer_funcs: list[Callable],
+        filter_funcs: list[Callable],
+        idx_generator_funcs: list[Callable],
+    ):
         """Initialize the pipeline."""
         self.src_conn = src_conn
         self.filter_funcs = filter_funcs

--- a/src/cloudimagedirectory/transform/transform.py
+++ b/src/cloudimagedirectory/transform/transform.py
@@ -15,10 +15,12 @@ class Pipeline:
     """Builds a pipeline of transformer tasks."""
 
     transformers: list[Callable] = []
+    filter_funcs: list[Callable] = []
 
-    def __init__(self, src_conn, transformer_funcs: list[Callable]):
+    def __init__(self, src_conn, transformer_funcs: list[Callable], filter_funcs: list[Callable]):
         """Initialize the pipeline."""
         self.src_conn = src_conn
+        self.filter_funcs = filter_funcs
         for transformer_func in transformer_funcs:
             self.transformers.append(transformer_func(self.src_conn))
 
@@ -27,6 +29,9 @@ class Pipeline:
         results = data
         for transformer in self.transformers:
             results.extend(transformer.run(results))
+
+        for filter_func in self.filter_funcs:
+            results = filter_func(results)
         return results
 
 

--- a/src/cloudimagedirectory/transformer.py
+++ b/src/cloudimagedirectory/transformer.py
@@ -1,8 +1,8 @@
 import click
 
 from cloudimagedirectory.connection import connection
-from cloudimagedirectory.transform import transform
 from cloudimagedirectory.filter import filter
+from cloudimagedirectory.transform import transform
 
 
 @click.command()

--- a/src/cloudimagedirectory/transformer.py
+++ b/src/cloudimagedirectory/transformer.py
@@ -51,6 +51,7 @@ def run(origin_path: str, destination_path: str, api: str, arg_files: str) -> No
             transform.TransformerIdxListImageLatestAWS,
             transform.TransformerIdxListImageLatestAZURE,
         ],
+        [],
     )
     print("run pipeline")
     results = pipeline.run(filenames)

--- a/src/cloudimagedirectory/transformer.py
+++ b/src/cloudimagedirectory/transformer.py
@@ -2,6 +2,7 @@ import click
 
 from cloudimagedirectory.connection import connection
 from cloudimagedirectory.transform import transform
+from cloudimagedirectory.filter import filter
 
 
 @click.command()
@@ -46,12 +47,17 @@ def run(origin_path: str, destination_path: str, api: str, arg_files: str) -> No
             transform.TransformerAWS,
             transform.TransformerAZURE,
             transform.TransformerGoogle,
+        ],
+        [
+            filter.FilterImageByFilename("test"),
+            filter.FilterImageByFilename("beta"),
+        ],
+        [
             transform.TransformerIdxListImageLatest,
             transform.TransformerIdxListImageLatestGoogle,
             transform.TransformerIdxListImageLatestAWS,
             transform.TransformerIdxListImageLatestAZURE,
         ],
-        [],
     )
     print("run pipeline")
     results = pipeline.run(filenames)


### PR DESCRIPTION
I restructured our pipeline a bit to execute filters before generating indexes. It was necessary to avoid dead links in our pre-generated lists.

```
filter images by filename: test
filter images by filename: beta
run pipeline
total images:  18781
filtered 603 items
filtered 867 items
generated indexes: 721
```

closes #453 
closes #452 