### PR TITLE
Create new format package to process rhel image data

### DIFF
--- a/src/cloudimagedirectory/format/format_aws.py
+++ b/src/cloudimagedirectory/format/format_aws.py
@@ -1,0 +1,79 @@
+import re
+
+def parse_image_name_rhel(image_name: str) -> dict[str, str]:
+    """Parse an AWS image name and return extra data about the image.
+
+    Regex101: https://regex101.com/r/mXCl73/1
+
+    Args:
+        image_name: String containing the image name, such as:
+                    RHEL-9.0.0_HVM_BETA-20211026-x86_64-10-Hourly2-GP2
+
+    Returns:
+        Dictionary with additional information about the image.
+    """
+    # See Regex101 link above to tinker with this regex. Each group is named to make
+    # it easier to handle parsed data. Explanation of names:
+    #
+    #     intprod = internal product (such as HA)
+    #     extprod = external product (such as SAP)
+    #     version = RHEL version (such as 9.0.0)
+    #     virt = virtualization type (such as HVM)
+    #     beta = beta vs non-beta release
+    #     date = date image was produced
+    #     arch = architecture (such as x86_64 or arm64)
+    #     release = release number of the image
+    #     billing = Hourly2 or Access2  #noqa: E800
+    #     storage = storage type (almost always GP2)
+    #
+    aws_image_name_regex = (
+        r"RHEL_*(?P<intprod>\w*)?-*(?P<extprod>\w*)?-(?P<version>[\d\-\.]*)_"
+        r"(?P<virt>[A-Z]*)_*(?P<beta>\w*)?-(?P<date>\d+)-(?P<arch>\w*)-"
+        r"(?P<release>\d+)-(?P<billing>[\w\d]*)-(?P<storage>\w*)"
+    )
+    matches = re.match(aws_image_name_regex, image_name, re.IGNORECASE)
+    if matches:
+        return matches.groupdict()
+
+    return {}
+
+
+def image_rhel(image: dict[str, str], region: str) -> dict[str, str]:
+    """Compile a dictionary of important image information.
+
+    Args:
+        images: A dictionary containing metadata about the image.
+        region: Name of the image region.
+
+    Returns:
+        JSON like structure containing streamlined image
+        information.
+    """
+    additional_information = parse_image_name_rhel(image["Name"])
+
+    arch = image["Architecture"]
+    image_id = image["ImageId"]
+    virt_type = image["VirtualizationType"]
+    date = image["CreationDate"]
+    version = additional_information["version"]
+    beta = additional_information["beta"]
+    billing = additional_information["billing"]
+    extprod = additional_information["extprod"]
+    intprod = additional_information["intprod"]
+    name_parts = ["RHEL", version, intprod, extprod, virt_type, arch, billing, beta]
+
+    name = " ".join([x for x in name_parts if x != ""])
+    selflink = (
+        f"https://console.aws.amazon.com/ec2/home?region={region}#launchAmi={image_id}"
+    )
+
+    return {
+        "name": name,
+        "arch": arch,
+        "version": version,
+        "imageId": image_id,
+        "date": date,
+        "virt": virt_type,
+        "selflink": selflink,
+        "region": region,
+    }

--- a/src/cloudimagedirectory/format/format_aws.py
+++ b/src/cloudimagedirectory/format/format_aws.py
@@ -1,5 +1,6 @@
 import re
 
+
 def parse_image_name_rhel(image_name: str) -> dict[str, str]:
     """Parse an AWS image name and return extra data about the image.
 

--- a/src/cloudimagedirectory/format/format_azure.py
+++ b/src/cloudimagedirectory/format/format_azure.py
@@ -1,0 +1,74 @@
+import re
+from datetime import datetime
+
+def parse_image_version_rhel(image_version: str) -> dict[str, str]:
+    """Parse an AWS image name and return extra data about the image.
+
+    Regex101: https://regex101.com/r/yHB9jJ/1
+
+    Args:
+        image_version: String containing the image version, such as:
+                    7.4.2021051102 or 9.0.0.2022053014
+
+    Returns:
+        Dictionary with additional information about the image.
+    """
+    # See Regex101 link above to tinker with this regex. Each group is named to make
+    # it easier to handle parsed data. Explanation of names:
+    #
+    #     version = RHEL version (such as 9.0)
+    #     date = date image was produced
+    #
+    aws_image_name_regex = (
+        r"(?P<version>[\d]+\.[\d]+(?:\.[\d]+)?)\.(?P<date>\d{4}\d{2}\d{2})"
+    )
+    matches = re.match(aws_image_name_regex, image_version, re.IGNORECASE)
+    if matches:
+        return matches.groupdict()
+
+    return {}
+
+
+def convert_date_rhel(date: str) -> str:
+    """Convert timestamp to date string This fallback is necessary as Azure
+    timestamps are inconsistent and can either follow yyyymmdd or yyyyddmm.
+
+    Returns:
+        Date as string following the structure "%Y-%m-%d"
+    """
+    try:
+        return datetime.strptime(date, "%Y%m%d").strftime("%Y-%m-%d")
+    except:
+        return datetime.strptime(date, "%Y%d%m").strftime("%Y-%m-%d")
+
+def image_rhel(image: dict[str, str]) -> dict[str, str]:
+    """Compile a dictionary of important image information.
+
+    Args:
+        images: A dictionary containing metadata about the image.
+
+    Returns:
+        JSON like structure containing streamlined image
+        information.
+    """
+    additional_information = parse_image_version_rhel(image["version"])
+
+    arch = image["architecture"]
+    image_id = image["urn"]
+    virt_type = image["hyperVGeneration"]
+    sku = image["sku"]
+    offer = image["offer"]
+
+    date = convert_date_rhel(additional_information["date"])
+    version = additional_information["version"]
+
+    name = f"{offer} {sku} {arch}"
+
+    return {
+        "name": name,
+        "arch": arch,
+        "version": version,
+        "imageId": image_id,
+        "date": date,
+        "virt": virt_type,
+    }

--- a/src/cloudimagedirectory/format/format_azure.py
+++ b/src/cloudimagedirectory/format/format_azure.py
@@ -1,5 +1,7 @@
 import re
+
 from datetime import datetime
+
 
 def parse_image_version_rhel(image_version: str) -> dict[str, str]:
     """Parse an AWS image name and return extra data about the image.
@@ -40,6 +42,7 @@ def convert_date_rhel(date: str) -> str:
         return datetime.strptime(date, "%Y%m%d").strftime("%Y-%m-%d")
     except:
         return datetime.strptime(date, "%Y%d%m").strftime("%Y-%m-%d")
+
 
 def image_rhel(image: dict[str, str]) -> dict[str, str]:
     """Compile a dictionary of important image information.

--- a/src/cloudimagedirectory/format/format_google.py
+++ b/src/cloudimagedirectory/format/format_google.py
@@ -1,0 +1,66 @@
+import re
+
+def parse_image_name_rhel(image_name: str) -> dict[str, str]:
+    """Parse an google image name and return version string.
+
+    Regex101: https://regex101.com/r/9QCWIJ/1
+
+    Args:
+        image_name: String containing the image name, such as:
+                    rhel-7-9-sap-v20220719
+
+    Returns:
+        Dictionary with additional information about the image.
+    """
+    google_image_name_regex = (
+        r"(?P<product>\w*)-(?P<version>[\d]+(?:\-[\d]){0,3})-?"
+        r"(?P<extprod>\w*)?-v(?P<date>\d{4}\d{2}\d{2})"
+    )
+
+    matches = re.match(google_image_name_regex, image_name, re.IGNORECASE)
+    if matches:
+        return matches.groupdict()
+
+    return {}
+
+def image_rhel(image: dict[str, str]) -> dict[str, str]:
+    """Compile a dictionary of important image information.
+
+    Args:
+        images: A dictionary containing metadata about the image.
+
+    Returns:
+        JSON like structure containing streamlined image
+        information.
+    """
+    additional_information = parse_image_name_rhel(image["name"])
+
+    arch = image["architecture"]
+    image_id = image["name"]
+    date = image["creation_timestamp"]
+    extprod = additional_information["extprod"]
+    version = additional_information["version"].replace("-", ".")
+
+    name_parts = ["RHEL", version, extprod]
+
+    # This is necessary to avoid creating names like "RHEL 9 arm64 arm64"
+    # as the naming conventions for Google images are inconsistent.
+    # e.g.
+    # rhel-9-arm64-v20221206
+    # rhel-7-6-sap-v20221102
+    if extprod.lower() != arch.lower():
+        name_parts.append(arch)
+
+    name = " ".join([x for x in name_parts if x != ""])
+
+    selflink = "https://console.cloud.google.com/compute/imagesDetail/"
+    selflink += f"projects/rhel-cloud/global/images/{image_id}"
+
+    return {
+        "name": name,
+        "arch": arch,
+        "version": version,
+        "imageId": image_id,
+        "date": date,
+        "selflink": selflink,
+    }

--- a/src/cloudimagedirectory/format/format_google.py
+++ b/src/cloudimagedirectory/format/format_google.py
@@ -1,5 +1,6 @@
 import re
 
+
 def parse_image_name_rhel(image_name: str) -> dict[str, str]:
     """Parse an google image name and return version string.
 
@@ -22,6 +23,7 @@ def parse_image_name_rhel(image_name: str) -> dict[str, str]:
         return matches.groupdict()
 
     return {}
+
 
 def image_rhel(image: dict[str, str]) -> dict[str, str]:
     """Compile a dictionary of important image information.

--- a/src/cloudimagedirectory/transform/transform.py
+++ b/src/cloudimagedirectory/transform/transform.py
@@ -6,10 +6,9 @@ from typing import Callable
 
 from cloudimagedirectory import config
 from cloudimagedirectory.connection import connection
-from cloudimagedirectory.update_images import aws
-from cloudimagedirectory.update_images import azure
-from cloudimagedirectory.update_images import google
-
+from cloudimagedirectory.format import format_google
+from cloudimagedirectory.format import format_aws
+from cloudimagedirectory.format import format_azure
 
 class Pipeline:
     """Builds a pipeline of transformer tasks."""
@@ -198,7 +197,7 @@ class TransformerAWS(Transformer):
                 if content["OwnerId"] != config.AWS_RHEL_OWNER_ID:
                     continue
 
-                image_data = aws.format_image(content, region)
+                image_data = format_aws.image_rhel(content, region)
                 image_name = image_data["name"].replace(" ", "_").lower()
                 data_entry = connection.DataEntry(
                     f"aws/{region}/{image_name}", image_data
@@ -221,7 +220,7 @@ class TransformerGoogle(Transformer):
             for content in raw.content:
                 content["creation_timestamp"] = content["creationTimestamp"]
                 if "rhel" in content["name"]:
-                    image_data = google.format_image(content)
+                    image_data = format_google.image_rhel(content)
                     image_name = image_data["name"].replace(" ", "_").lower()
                     data_entry = connection.DataEntry(
                         f"google/global/{image_name}", image_data
@@ -251,7 +250,7 @@ class TransformerAZURE(Transformer):
                 content["hyperVGeneration"] = "unknown"
 
                 try:
-                    image_data = azure.format_image(content)
+                    image_data = format_azure.image_rhel(content)
                     image_name = image_data["name"].replace(" ", "_").lower()
                     data_entry = connection.DataEntry(
                         f"azure/{region}/{image_name}", image_data

--- a/src/cloudimagedirectory/transform/transform.py
+++ b/src/cloudimagedirectory/transform/transform.py
@@ -6,9 +6,10 @@ from typing import Callable
 
 from cloudimagedirectory import config
 from cloudimagedirectory.connection import connection
-from cloudimagedirectory.format import format_google
 from cloudimagedirectory.format import format_aws
 from cloudimagedirectory.format import format_azure
+from cloudimagedirectory.format import format_google
+
 
 class Pipeline:
     """Builds a pipeline of transformer tasks."""


### PR DESCRIPTION
In this PR, I have extracted the formatting functions from our old cli into a new package and split them into different files for each cloud provider, to make it easier to keep an overview and to make it easier to add the Fedora image formatting later.

closes #483 